### PR TITLE
unit test domain object save issue

### DIFF
--- a/grails-app/domain/org/tyusupov/TestObj.groovy
+++ b/grails-app/domain/org/tyusupov/TestObj.groovy
@@ -1,0 +1,9 @@
+package org.tyusupov
+
+/**
+ * @author Timur
+ * @date 2016-04-28.
+ */
+class TestObj {
+    String name
+}

--- a/grails-app/domain/org/tyusupov/TestObj2.groovy
+++ b/grails-app/domain/org/tyusupov/TestObj2.groovy
@@ -1,0 +1,9 @@
+package org.tyusupov
+
+/**
+ * @author Timur
+ * @date 2016-04-28.
+ */
+class TestObj2 {
+    String name
+}

--- a/test/unit/org/tyusupov/TestSpec.groovy
+++ b/test/unit/org/tyusupov/TestSpec.groovy
@@ -1,5 +1,6 @@
 package org.tyusupov
 
+import grails.test.mixin.Mock
 import grails.test.mixin.TestMixin
 import grails.test.mixin.domain.DomainClassUnitTestMixin
 import spock.lang.Specification
@@ -9,6 +10,7 @@ import spock.lang.Specification
  * @date 2016-04-28.
  */
 @TestMixin(DomainClassUnitTestMixin)
+@Mock([TestObj, TestObj2])
 class TestSpec extends Specification {
 
     def setup() {

--- a/test/unit/org/tyusupov/TestSpec.groovy
+++ b/test/unit/org/tyusupov/TestSpec.groovy
@@ -1,0 +1,22 @@
+package org.tyusupov
+
+import grails.test.mixin.TestMixin
+import grails.test.mixin.domain.DomainClassUnitTestMixin
+import org.tyusupov.TestObj
+import spock.lang.Specification
+
+/**
+ * @author Timur
+ * @date 2016-04-28.
+ */
+@TestMixin(DomainClassUnitTestMixin)
+class TestSpec extends Specification {
+
+    def setup() {
+        new TestObj(name: "name").save(failOnError: false, flush: true)
+    }
+
+    def "test"() {
+        expect: true
+    }
+}

--- a/test/unit/org/tyusupov/TestSpec.groovy
+++ b/test/unit/org/tyusupov/TestSpec.groovy
@@ -2,7 +2,6 @@ package org.tyusupov
 
 import grails.test.mixin.TestMixin
 import grails.test.mixin.domain.DomainClassUnitTestMixin
-import org.tyusupov.TestObj
 import spock.lang.Specification
 
 /**
@@ -14,6 +13,7 @@ class TestSpec extends Specification {
 
     def setup() {
         new TestObj(name: "name").save(failOnError: false, flush: true)
+        new TestObj2(name: "name").save(failOnError: false, flush: true)
     }
 
     def "test"() {


### PR DESCRIPTION
Running `grails test-app` on jdk1.7.0_80 gives following issue on commit https://github.com/ttyusupov/grails-test-2-5-4/pull/1/commits/9523a4583d0790b48128f26243f4d2dfcdcf5a48:

```
|Loading Grails 2.5.4
|Configuring classpath
.
|Environment set to test
....................................
|Running without daemon...
...........................................
|Running 2 unit tests...
|Running 2 unit tests... 1 of 2
Failure:  |
test(org.tyusupov.TestSpec)
 |
java.lang.IllegalStateException: Method on class [org.tyusupov.TestObj] was used outside of a Grails application. If running in the context of a test using the mocking API or bootstrap Grails correctly.
    at org.tyusupov.TestSpec.setup(TestSpec.groovy:16)
|Completed 1 unit test, 1 failed in 0m 3s
.................Tests FAILED 
```

_Fixed_ test in commit https://github.com/ttyusupov/grails-test-2-5-4/pull/1/commits/bcb5c6c81eac3bb68d48a583bfe7556990b7f1ec:

```
grails test-app
|Loading Grails 2.5.4
|Configuring classpath
.
|Environment set to test
....................................
|Running without daemon...
...........................................
|Running 2 unit tests...
|Running 2 unit tests... 1 of 2
|Completed 1 unit test, 0 failed in 0m 5s
.................
|Tests PASSED - view reports in C:\Projects\my\grails\grails-test-2-5-4\target\test-reports
```
